### PR TITLE
 xmir-helper: set environments to make the app uses X11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,8 @@ export DPKG_GENSYMBOLS_CHECK_LEVEL=4
 ifneq (,$(findstring cross,$(DEB_BUILD_PROFILES)))
 UAL_DH_OPTIONS = --with click
 CONFIGURE_OPTS += -Denable_introspection=OFF -Denable_abi_checker=OFF
+# Workaround pkg-create-dbgsym bug
+DH_STRIP_OPTIONS := --no-package=gir1.2-ubuntu-app-launch-2
 else
 UAL_DH_OPTIONS = --with click,gir
 endif
@@ -34,6 +36,9 @@ ifneq (,$(findstring cross,$(DEB_BUILD_PROFILES)))
 	touch debian/tmp/usr/share/gir-1.0/void
 endif
 	dh_auto_install --parallel
+
+override_dh_strip:
+	dh_strip $(DH_STRIP_OPTIONS)
 
 override_dh_installdeb:
 	sed -e"s/#MULTIARCH#/$(DEB_HOST_MULTIARCH)/g" \

--- a/xmir-helper.c
+++ b/xmir-helper.c
@@ -110,6 +110,20 @@ main (int argc, char * argv[])
 	/* Set up the display variable */
 	setenv("DISPLAY", displaynumber, 1);
 
+	/*
+	 * Make sure the app will use X11.
+	 * See:
+	 *   - https://wiki.archlinux.org/index.php/Wayland#GUI_libraries
+	 *   - https://github.com/5paceToast/axerc/blob/cf11e5dd1912291bd9afd83fb7beaef95c85ea4a/axerc#L45
+	 */
+
+	setenv("XDG_SESSION_TYPE", "x11", /* replace */ 1);
+	setenv("GDK_BACKEND", "x11", /* replace */ 1);
+	setenv("QT_QPA_PLATFORM", "xcb", /* replace */ 1);
+	setenv("CLUTTER_BACKEND", "x11", /* replace */ 1);
+	setenv("SDL_VIDEODRIVER", "x11", /* replace */ 1);
+	setenv("ELM_DISPLAY", "x11", /* replace */ 1);
+
 	/* Now that we have everything setup, we can execute */
 	char ** nargv = &argv[2];
 	int execret = execvp(nargv[0], nargv);


### PR DESCRIPTION
Especially for GTK+3 apps, it will crash if it uses Wayland. To be safe,
just set all the known environments that tell the app to use X11.

Fixes ubports/ubuntu-touch#1407

This PR also comes with Jenkinsfile update and a workaround for cross-building.