### PR TITLE
Do not wait for handshake before triggering upstart

### DIFF
--- a/libubuntu-app-launch/application-impl-base.cpp
+++ b/libubuntu-app-launch/application-impl-base.cpp
@@ -857,10 +857,6 @@ std::shared_ptr<UpstartInstance> UpstartInstance::launch(
             auto chelper = new StartCHelper{};
             chelper->ptr = retval;
 
-            tracepoint(ubuntu_app_launch, handshake_wait, appIdStr.c_str());
-            starting_handshake_wait(handshake);
-            tracepoint(ubuntu_app_launch, handshake_complete, appIdStr.c_str());
-
             /* Call the job start function */
             g_debug("Asking Upstart to start task for: %s", appIdStr.c_str());
             g_dbus_connection_call(registry->impl->_dbus.get(),                   /* bus */
@@ -878,6 +874,10 @@ std::shared_ptr<UpstartInstance> UpstartInstance::launch(
                                    );
 
             tracepoint(ubuntu_app_launch, libual_start_message_sent, appIdStr.c_str());
+
+            tracepoint(ubuntu_app_launch, handshake_wait, appIdStr.c_str());
+            starting_handshake_wait(handshake);
+            tracepoint(ubuntu_app_launch, handshake_complete, appIdStr.c_str());
 
             return retval;
         });


### PR DESCRIPTION
We have no need to wait for handshake as this has no benefit at all

The hanshake exists to let qtmir know a application is starting, but
this is not needed to be sendt before the exec of the app has begun. if
the application is started by qtmir, it will know immediately that an
app is starting so this signal is unused by qtmir. This handshake
sometimes takes 0.5s as it does many roundtrips and we simply dont need
to wait that long before exec an application.